### PR TITLE
Use https URLs for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,45 +1,45 @@
 [submodule "src/github.com/ccding/go-config-reader"]
 	path = src/github.com/ccding/go-config-reader
-	url = http://github.com/ccding/go-config-reader
+	url = https://github.com/ccding/go-config-reader.git
 [submodule "src/github.com/ccding/go-logging"]
 	path = src/github.com/ccding/go-logging
-	url = http://github.com/ccding/go-logging
+	url = https://github.com/ccding/go-logging.git
 [submodule "src/github.com/cloudfoundry/go_cfmessagebus"]
 	path = src/github.com/cloudfoundry/go_cfmessagebus
-	url = http://github.com/cloudfoundry/go_cfmessagebus
+	url = https://github.com/cloudfoundry/go_cfmessagebus.git
 [submodule "src/github.com/cloudfoundry/hm9000"]
 	path = src/github.com/cloudfoundry/hm9000
-	url = http://github.com/cloudfoundry/hm9000
+	url = https://github.com/cloudfoundry/hm9000.git
 [submodule "src/github.com/cloudfoundry/yagnats"]
 	path = src/github.com/cloudfoundry/yagnats
-	url = http://github.com/cloudfoundry/yagnats
+	url = https://github.com/cloudfoundry/yagnats.git
 [submodule "src/github.com/codegangsta/cli"]
 	path = src/github.com/codegangsta/cli
-	url = http://github.com/codegangsta/cli
+	url = https://github.com/codegangsta/cli.git
 [submodule "src/github.com/coreos/etcd"]
 	path = src/github.com/coreos/etcd
-	url = http://github.com/coreos/etcd
+	url = https://github.com/coreos/etcd.git
 [submodule "src/github.com/coreos/go-etcd"]
 	path = src/github.com/coreos/go-etcd
-	url = http://github.com/coreos/go-etcd
+	url = https://github.com/coreos/go-etcd.git
 [submodule "src/github.com/coreos/go-log"]
 	path = src/github.com/coreos/go-log
-	url = http://github.com/coreos/go-log
+	url = https://github.com/coreos/go-log.git
 [submodule "src/github.com/coreos/go-raft"]
 	path = src/github.com/coreos/go-raft
-	url = http://github.com/coreos/go-raft
+	url = https://github.com/coreos/go-raft.git
 [submodule "src/github.com/coreos/go-systemd"]
 	path = src/github.com/coreos/go-systemd
-	url = http://github.com/coreos/go-systemd
+	url = https://github.com/coreos/go-systemd.git
 [submodule "src/github.com/nu7hatch/gouuid"]
 	path = src/github.com/nu7hatch/gouuid
-	url = http://github.com/nu7hatch/gouuid
+	url = https://github.com/nu7hatch/gouuid.git
 [submodule "src/github.com/onsi/ginkgo"]
 	path = src/github.com/onsi/ginkgo
-	url = http://github.com/onsi/ginkgo
+	url = https://github.com/onsi/ginkgo.git
 [submodule "src/github.com/onsi/gomega"]
 	path = src/github.com/onsi/gomega
-	url = http://github.com/onsi/gomega
+	url = https://github.com/onsi/gomega.git
 [submodule "src/github.com/samuel/go-zookeeper"]
 	path = src/github.com/samuel/go-zookeeper
-	url = http://github.com/samuel/go-zookeeper
+	url = https://github.com/samuel/go-zookeeper.git


### PR DESCRIPTION
I found that checking out submodules fails on Ubuntu 10.04.
Since the Git version on lucid is older and has some issues on submodule URLs which are redirected to other URLs,
I replaced all the submodule URLs with the redirected URLs.
