### PR TITLE
hm9000 templates now host check against consul.service.cf.internal

### DIFF
--- a/jobs/hm9000/templates/hm9000_analyzer_ctl
+++ b/jobs/hm9000/templates/hm9000_analyzer_ctl
@@ -12,7 +12,7 @@ case $1 in
 
   start)
     set +e
-    host hm9000.service.cf.internal
+    host consul.service.cf.internal
     if [[ "0" != "$?" ]]; then
       echo "DNS is not up"
       exit 1

--- a/jobs/hm9000/templates/hm9000_api_server_ctl
+++ b/jobs/hm9000/templates/hm9000_api_server_ctl
@@ -10,7 +10,7 @@ case $1 in
 
   start)
     set +e
-    host hm9000.service.cf.internal
+    host consul.service.cf.internal
     if [[ "0" != "$?" ]]; then
       echo "DNS is not up"
       exit 1

--- a/jobs/hm9000/templates/hm9000_evacuator_ctl
+++ b/jobs/hm9000/templates/hm9000_evacuator_ctl
@@ -10,7 +10,7 @@ case $1 in
 
   start)
     set +e
-    host hm9000.service.cf.internal
+    host consul.service.cf.internal
     if [[ "0" != "$?" ]]; then
       echo "DNS is not up"
       mon 1

--- a/jobs/hm9000/templates/hm9000_listener_ctl
+++ b/jobs/hm9000/templates/hm9000_listener_ctl
@@ -10,7 +10,7 @@ case $1 in
 
   start)
     set +e
-    host hm9000.service.cf.internal
+    host consul.service.cf.internal
     if [[ "0" != "$?" ]]; then
       echo "DNS is not up"
       exit 1

--- a/jobs/hm9000/templates/hm9000_shredder_ctl
+++ b/jobs/hm9000/templates/hm9000_shredder_ctl
@@ -10,7 +10,7 @@ case $1 in
 
   start)
     set +e
-    host hm9000.service.cf.internal
+    host consul.service.cf.internal
     if [[ "0" != "$?" ]]; then
       echo "DNS is not up"
       exit 1


### PR DESCRIPTION
We ran into deployment issues while upgrading consul from 0.5.2 to 0.6.4, due to the host checks in the hm9000 ctl scripts checking `hm9000.service.cf.internal`. This worked in consul 0.5.2 due to DNS resolution incorrectly resolving the existence of a DNS entry before the service was actually up and running.

This fix will ensure that DNS is up and running and is compatible with both consul 0.5.2 and consul 0.6.4.

cc @kkallday